### PR TITLE
tabs/spaces inconsistency (throws error)

### DIFF
--- a/main0.py
+++ b/main0.py
@@ -116,7 +116,7 @@ def do_settings():
     global F_LIMIT
     global pb
     global PUSHPOKS
-	global centralscan
+    global centralscan
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-id", "--id", help="worker id")


### PR DESCRIPTION
couldn’t get the script to run without fixing one (newish?) tab that should be 4 spaces.
