### PR TITLE
Added the option to push to pushbullet channels

### DIFF
--- a/main0.py
+++ b/main0.py
@@ -183,7 +183,12 @@ def do_settings():
         for a in range (len(keys)):
             try:
                 this_pb = Pushbullet(keys[a])
-                pb.append(this_pb)
+                if allsettings['pushbullet']['use_channels'] is True:
+                    for channel in this_pb.channels:
+                        if channel.channel_tag in allsettings['pushbullet']['channel_tags']:
+                            pb.append(channel)
+                else:
+                    pb.append(this_pb)
             except Exception as e:
                 lprint('[-] Pushbullet error, key {} is invalid, {}'.format(a+1, e))
                 lprint('[-] This pushbullet will be disabled.')

--- a/res/usersettings.json
+++ b/res/usersettings.json
@@ -34,6 +34,8 @@
   {
       "enabled": false,
       "api_key": ["PUT_YOUR_PUSHBULLET_API_KEY_HERE"],
+      "use_channels": false,
+      "channel_tags": [],
       "push_ids": []
   },
   


### PR DESCRIPTION
if "use_channels" is set to false it pushes to the defined api keys. (and works exactly the same as before)

if "use_channels" is set to true it looks for the defined channel tags in the accounts set by the defined api keys and pushes to those channels.
Channels are easier for pushing to other people cause you dont have to ask for an apikey, only refer them to an url to join your channel.
