### PR TITLE
Remove ES6 arrow function for iOS compatibility

### DIFF
--- a/webres/index.html
+++ b/webres/index.html
@@ -164,7 +164,7 @@
         /////////////////////////////////////////////////////////////////////
         function cleanWholedata() {
             var timenow = Math.round((new Date()).getTime() / 1000);
-            wholedata = wholedata.filter(entry => entry[5] > timenow);
+            wholedata = wholedata.filter(function(entry) {return entry[5] > timenow});
             localStorage.setItem('pokedata' + profile, JSON.stringify(wholedata));
             localStorage.setItem('datatill' + profile, datatill.toString());
         }


### PR DESCRIPTION
Current website hosted by pokesite.py does not work on iOS browsers (iOS9 Safari/Chrome) due to iOS's lack of ES6 support. This fixes it by converting the arrow function to a standard function.
