### PR TITLE
Remove duplicate 'requests' from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 protobuf==3.0.0b4
-requests
 s2sphere==0.2.4
 gpsoauth==0.3.0
 pushbullet.py


### PR DESCRIPTION
`pip install -r requirements` currently aborts with an error about duplicate requirements. there's 'requests' and 'requests[socks]' in the requirements.txt. this commit removes the 'requests' line.
