### PR TITLE
Disable Telegram by default

### DIFF
--- a/res/usersettings.json.example
+++ b/res/usersettings.json.example
@@ -37,7 +37,7 @@
 	},
 	"telegram":
 	{
-		"enabled": true,
+		"enabled": false,
 		"bot_token": "PUT_YOUR_TELEGRAM_BOT_TOKEN_HERE",
 		"chat_ids":["PUT_YOUR_CHAT_ID_HERE"]
 	}


### PR DESCRIPTION
Since Telegram requires extra work (bot_token and chat_ids), it's better to disable it by default and let users who supply this extra info enable it explicitely.
