### PR TITLE
Disable Telegram notification for the location message

### DIFF
--- a/main0.py
+++ b/main0.py
@@ -1750,7 +1750,7 @@ def main():
                                 for telegram in telegrams:
                                     try:
                                         telebot.sendMessage(chat_id=telegram, text='<b>' + notification_text + '</b>\n' + time_text, parse_mode='HTML', disable_web_page_preview='False', disable_notification='False')
-                                        telebot.sendLocation(chat_id=telegram, latitude=wild.latitude, longitude=wild.longitude)
+                                        telebot.sendLocation(chat_id=telegram, latitude=wild.latitude, longitude=wild.longitude, disable_notification='True')
                                     except Exception as e:
                                         lprint('[-] Connection Error during Telegram, error: {}'.format(e))
                             if addpokemon.empty() and time.time() < nextdatwrite:


### PR DESCRIPTION
Since users will already get a notification for the text message, there's no need for a second notification on the location message. Also has the added benefit of not showing "Location" as the last notification, but the related text.
