### PR TITLE
Remove account number from empty cell message

### DIFF
--- a/main0.py
+++ b/main0.py
@@ -1594,7 +1594,7 @@ def main():
                                 empty_loc[all_loc.index(location)] += 1
                                 pres_empty += 1
                             else:
-                                lprint('[{}] Non-empty cell returned as empty.'.format(self.account['num']))
+                                lprint('[-] Non-empty cell returned as empty.')
                         else:
                             if dumb or not smartscan:
                                 empty_loc[all_loc.index(location)] = 0


### PR DESCRIPTION
Having the account number isn't very helpful since it's just an index of what accounts you're currently running. And what I mean by that is telling you account #19 returned an empty cell would require you to go look at the ID currently being run for the 19th account. Username would be more helpful, but that seems to be handled by the `captchaX.txt` file.
